### PR TITLE
Add shared_port robot type with port sharing between leader and follower arms

### DIFF
--- a/docker/lerobot-gpu/Dockerfile
+++ b/docker/lerobot-gpu/Dockerfile
@@ -21,4 +21,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY . /lerobot
 WORKDIR /lerobot
 RUN /opt/venv/bin/pip install --upgrade --no-cache-dir pip \
-    && /opt/venv/bin/pip install --no-cache-dir ".[test, aloha, xarm, pusht, dynamixel]"
+    && /opt/venv/bin/pip install --no-cache-dir ".[test, aloha, xarm, pusht, dynamixel, feetech]"

--- a/lerobot/__init__.py
+++ b/lerobot/__init__.py
@@ -181,6 +181,7 @@ available_robots = [
     "koch_bimanual",
     "aloha",
     "so100",
+    "so100_shared_port"
     "so101",
     "moss",
 ]

--- a/lerobot/common/robot_devices/motors/utils.py
+++ b/lerobot/common/robot_devices/motors/utils.py
@@ -30,7 +30,7 @@ class MotorsBus(Protocol):
     def write(self): ...
 
 
-def make_motors_buses_from_configs(motors_bus_configs: dict[str, MotorsBusConfig]) -> list[MotorsBus]:
+def make_motors_buses_from_configs(motors_bus_configs: dict[str, MotorsBusConfig], reuse_port=None) -> list[MotorsBus]:
     motors_buses = {}
 
     for key, cfg in motors_bus_configs.items():
@@ -41,14 +41,15 @@ def make_motors_buses_from_configs(motors_bus_configs: dict[str, MotorsBusConfig
 
         elif cfg.type == "feetech":
             from lerobot.common.robot_devices.motors.feetech import FeetechMotorsBus
-
-            motors_buses[key] = FeetechMotorsBus(cfg)
+            if reuse_port is not None:
+                motors_buses[key] = FeetechMotorsBus(cfg, reuse_port=reuse_port)
+            else:
+                motors_buses[key] = FeetechMotorsBus(cfg)
 
         else:
             raise ValueError(f"The motor type '{cfg.type}' is not valid.")
 
     return motors_buses
-
 
 def make_motors_bus(motor_type: str, **kwargs) -> MotorsBus:
     if motor_type == "dynamixel":

--- a/lerobot/common/robot_devices/robots/configs.py
+++ b/lerobot/common/robot_devices/robots/configs.py
@@ -537,6 +537,62 @@ class So100RobotConfig(ManipulatorRobotConfig):
         }
     )
 
+@RobotConfig.register_subclass("shared_port")
+@dataclass
+class SharedPortRobotConfig(ManipulatorRobotConfig):
+    calibration_dir: str = ".cache/calibration/shared_port"
+    # `max_relative_target` limits the magnitude of the relative positional target vector for safety purposes.
+    # Set this to a positive scalar to have the same value for all motors, or a list that is the same length as
+    # the number of motors in your follower arms.
+    max_relative_target: int | None = None
+
+    # Define a function to create the shared port configuration
+    @staticmethod
+    def create_shared_config():
+        # Define the shared port
+        shared_port = "/dev/tty.usbmodem58760431091"
+        
+        leader_config = {
+            "main": FeetechMotorsBusConfig(
+                port=shared_port,
+                motors={
+                    # name: (index, model)
+                    "shoulder_pan": [1, "sts3215"],
+                    "shoulder_lift": [2, "sts3215"],
+                    "elbow_flex": [3, "sts3215"],
+                    "wrist_flex": [4, "sts3215"],
+                    "wrist_roll": [5, "sts3215"],
+                    "gripper": [6, "sts3215"],
+                },
+            ),
+        }
+        
+        follower_config = {
+            "main": FeetechMotorsBusConfig(
+                port=shared_port,
+                motors={
+                    # name: (index, model) - IDs 7-12 instead of 1-6
+                    "shoulder_pan": [7, "sts3215"],
+                    "shoulder_lift": [8, "sts3215"],
+                    "elbow_flex": [9, "sts3215"],
+                    "wrist_flex": [10, "sts3215"],
+                    "wrist_roll": [11, "sts3215"],
+                    "gripper": [12, "sts3215"],
+                },
+            ),
+        }
+        
+        return leader_config, follower_config
+
+    # Use the shared configuration for leader and follower arms
+    leader_arms: dict[str, MotorsBusConfig] = field(
+        default_factory=lambda: SharedPortRobotConfig.create_shared_config()[0]
+    )
+
+    follower_arms: dict[str, MotorsBusConfig] = field(
+        default_factory=lambda: SharedPortRobotConfig.create_shared_config()[1]
+    )
+
     cameras: dict[str, CameraConfig] = field(
         default_factory=lambda: {
             "laptop": OpenCVCameraConfig(

--- a/lerobot/common/robot_devices/robots/configs.py
+++ b/lerobot/common/robot_devices/robots/configs.py
@@ -537,10 +537,10 @@ class So100RobotConfig(ManipulatorRobotConfig):
         }
     )
 
-@RobotConfig.register_subclass("shared_port")
+@RobotConfig.register_subclass("so100_shared_port")
 @dataclass
 class SharedPortRobotConfig(ManipulatorRobotConfig):
-    calibration_dir: str = ".cache/calibration/shared_port"
+    calibration_dir: str = ".cache/calibration/so100_shared_port"
     # `max_relative_target` limits the magnitude of the relative positional target vector for safety purposes.
     # Set this to a positive scalar to have the same value for all motors, or a list that is the same length as
     # the number of motors in your follower arms.
@@ -550,7 +550,7 @@ class SharedPortRobotConfig(ManipulatorRobotConfig):
     @staticmethod
     def create_shared_config():
         # Define the shared port
-        shared_port = "/dev/tty.usbmodem58760431091"
+        shared_port = "/dev/ttyUSB0"
         
         leader_config = {
             "main": FeetechMotorsBusConfig(

--- a/lerobot/common/robot_devices/robots/feetech_calibration.py
+++ b/lerobot/common/robot_devices/robots/feetech_calibration.py
@@ -149,6 +149,8 @@ def apply_offset(calib, offset):
 def run_arm_auto_calibration(arm: MotorsBus, robot_type: str, arm_name: str, arm_type: str):
     if robot_type == "so100":
         return run_arm_auto_calibration_so100(arm, robot_type, arm_name, arm_type)
+    elif robot_type == "so100_shared_port":
+        return run_arm_auto_calibration_so100(arm, robot_type, arm_name, arm_type)
     elif robot_type == "moss":
         return run_arm_auto_calibration_moss(arm, robot_type, arm_name, arm_type)
     else:

--- a/lerobot/common/robot_devices/robots/manipulator.py
+++ b/lerobot/common/robot_devices/robots/manipulator.py
@@ -161,8 +161,30 @@ class ManipulatorRobot:
         self.config = config
         self.robot_type = self.config.type
         self.calibration_dir = Path(self.config.calibration_dir)
-        self.leader_arms = make_motors_buses_from_configs(self.config.leader_arms)
-        self.follower_arms = make_motors_buses_from_configs(self.config.follower_arms)
+        
+        # Special handling for shared_port robot type
+        if self.robot_type == "shared_port":
+            # Create leader arms first
+            self.leader_arms = make_motors_buses_from_configs(self.config.leader_arms)
+            
+            # For follower arms, we need to create a special config that reuses the same port instance
+            from lerobot.common.robot_devices.motors.feetech import FeetechMotorsBus
+            
+            # Create follower arms manually, reusing the leader arm's port
+            self.follower_arms = {}
+            for key, leader_bus in self.leader_arms.items():
+                if key in self.config.follower_arms:
+                    follower_config = self.config.follower_arms[key]
+                    # Create a new FeetechMotorsBus with the follower config but reuse the leader's port
+                    self.follower_arms[key] = FeetechMotorsBus(
+                        follower_config, 
+                        reuse_port=leader_bus._port  # Reuse the port from leader
+                    )
+        else:
+            # Normal initialization for other robot types
+            self.leader_arms = make_motors_buses_from_configs(self.config.leader_arms)
+            self.follower_arms = make_motors_buses_from_configs(self.config.follower_arms)
+            
         self.cameras = make_cameras_from_configs(self.config.cameras)
         self.is_connected = False
         self.logs = {}
@@ -243,7 +265,7 @@ class ManipulatorRobot:
 
         if self.robot_type in ["koch", "koch_bimanual", "aloha"]:
             from lerobot.common.robot_devices.motors.dynamixel import TorqueMode
-        elif self.robot_type in ["so100", "so101", "moss", "lekiwi"]:
+        elif self.robot_type in ["so100", "so101", "moss", "lekiwi", "shared_port"]:
             from lerobot.common.robot_devices.motors.feetech import TorqueMode
 
         # We assume that at connection time, arms are in a rest position, and torque can
@@ -260,7 +282,7 @@ class ManipulatorRobot:
             self.set_koch_robot_preset()
         elif self.robot_type == "aloha":
             self.set_aloha_robot_preset()
-        elif self.robot_type in ["so100", "so101", "moss", "lekiwi"]:
+        elif self.robot_type in ["so100", "so101", "moss", "lekiwi", "shared_port"]:
             self.set_so100_robot_preset()
 
         # Enable torque on all motors of the follower arms
@@ -313,7 +335,7 @@ class ManipulatorRobot:
 
                     calibration = run_arm_calibration(arm, self.robot_type, name, arm_type)
 
-                elif self.robot_type in ["so100", "so101", "moss", "lekiwi"]:
+                elif self.robot_type in ["so100", "so101", "moss", "lekiwi", "shared_port"]:
                     from lerobot.common.robot_devices.robots.feetech_calibration import (
                         run_arm_manual_calibration,
                     )

--- a/lerobot/common/robot_devices/robots/utils.py
+++ b/lerobot/common/robot_devices/robots/utils.py
@@ -25,6 +25,7 @@ from lerobot.common.robot_devices.robots.configs import (
     So100RobotConfig,
     So101RobotConfig,
     StretchRobotConfig,
+    SharedPortRobotConfig,
 )
 
 
@@ -65,6 +66,8 @@ def make_robot_config(robot_type: str, **kwargs) -> RobotConfig:
         return StretchRobotConfig(**kwargs)
     elif robot_type == "lekiwi":
         return LeKiwiRobotConfig(**kwargs)
+    elif robot_type == "so100_shared_port":
+        return SharedPortRobotConfig(**kwargs)
     else:
         raise ValueError(f"Robot type '{robot_type}' is not available.")
 


### PR DESCRIPTION
## 概要
このPRでは、ManipulatorRobotクラスに新しいロボットタイプ「shared_port」を追加しました。このロボットタイプは、リーダーアームとフォロワーアームの間でポートを共有し、フォロワーモーターのIDを7〜12に設定します。

## 変更内容
1. `configs.py`に`SharedPortRobotConfig`クラスを追加
   - `create_shared_config()`静的メソッドを実装してリーダーとフォロワーの設定を共有
   - フォロワーモーターのIDを7〜12に設定

2. `feetech.py`の`FeetechMotorsBus`クラスを修正
   - `reuse_port`パラメータを追加して、ポートの再利用をサポート
   - ポートを閉じる際の処理を改善して、共有ポートが誤って閉じられないようにする

3. `manipulator.py`の`ManipulatorRobot`クラスを更新
   - `shared_port`ロボットタイプの特別な初期化処理を追加
   - リーダーアームのポートをフォロワーアームで再利用する処理を実装
   - 条件文に`shared_port`を追加

## テスト
この変更により、リーダーアームとフォロワーアームが同じポートを共有できるようになり、フォロワーモーターのIDが7〜12に設定されます。これにより、ポートの競合を避けながら、両方のアームを制御できます。